### PR TITLE
php: remove unneeded `type="text/javascript"` from HTML `script` tags

### DIFF
--- a/en/executive-committee.php
+++ b/en/executive-committee.php
@@ -78,6 +78,6 @@ $en = true;
 
         <?php include "_inc/_footer.php" ?>
 
-        <script type="text/javascript" src="/script.js?ver=1"></script>
+        <script src="/script.js?ver=1"></script>
     </body>
 </html>

--- a/en/index.php
+++ b/en/index.php
@@ -112,6 +112,6 @@ $is_home = true;
 
         <?php include "_inc/_footer.php" ?>
 
-        <script type="text/javascript" src="/script.js?ver=1"></script>
+        <script src="/script.js?ver=1"></script>
     </body>
 </html>

--- a/en/objectives.php
+++ b/en/objectives.php
@@ -22,6 +22,6 @@ $en = true;
 
         <?php include "_inc/_footer.php" ?>
 
-        <script type="text/javascript" src="/script.js?ver=1"></script>
+        <script src="/script.js?ver=1"></script>
     </body>
 </html>

--- a/en/registration.php
+++ b/en/registration.php
@@ -37,6 +37,6 @@ Email:
 
         <?php include "_inc/_footer.php" ?>
 
-        <script type="text/javascript" src="/script.js?ver=1"></script>
+        <script src="/script.js?ver=1"></script>
     </body>
 </html>

--- a/en/scientific-committee.php
+++ b/en/scientific-committee.php
@@ -220,6 +220,6 @@
 
         <?php include "_inc/_footer.php" ?>
 
-        <script type="text/javascript" src="/script.js?ver=1"></script>
+        <script src="/script.js?ver=1"></script>
     </body>
 </html>

--- a/en/speakers.php
+++ b/en/speakers.php
@@ -147,6 +147,6 @@ $en = true;
 
         <?php include "_inc/_footer.php" ?>
 
-        <script type="text/javascript" src="/script.js?ver=1"></script>
+        <script src="/script.js?ver=1"></script>
     </body>
 </html>

--- a/en/submit.php
+++ b/en/submit.php
@@ -66,6 +66,6 @@ require "../_submit.php";
 
         <?php include "_inc/_footer.php" ?>
 
-        <script type="text/javascript" src="/script.js?ver=1"></script>
+        <script src="/script.js?ver=1"></script>
     </body>
 </html>

--- a/fa/executive-committee.php
+++ b/fa/executive-committee.php
@@ -74,6 +74,6 @@
 
         <?php include "_inc/_footer.php" ?>
 
-        <script type="text/javascript" src="/script.js?ver=1"></script>
+        <script src="/script.js?ver=1"></script>
     </body>
 </html>

--- a/fa/index.php
+++ b/fa/index.php
@@ -155,6 +155,6 @@ $is_home = true;
 
         <?php include "_inc/_footer.php" ?>
 
-        <script type="text/javascript" src="/script.js?ver=1"></script>
+        <script src="/script.js?ver=1"></script>
     </body>
 </html>

--- a/fa/objectives.php
+++ b/fa/objectives.php
@@ -19,6 +19,6 @@
 
         <?php include "_inc/_footer.php" ?>
 
-        <script type="text/javascript" src="/script.js?ver=1"></script>
+        <script src="/script.js?ver=1"></script>
     </body>
 </html>

--- a/fa/registration.php
+++ b/fa/registration.php
@@ -36,6 +36,6 @@
 
         <?php include "_inc/_footer.php" ?>
 
-        <script type="text/javascript" src="/script.js?ver=1"></script>
+        <script src="/script.js?ver=1"></script>
     </body>
 </html>

--- a/fa/scientific-committee.php
+++ b/fa/scientific-committee.php
@@ -221,6 +221,6 @@
 
         <?php include "_inc/_footer.php" ?>
 
-        <script type="text/javascript" src="/script.js?ver=1"></script>
+        <script src="/script.js?ver=1"></script>
     </body>
 </html>

--- a/fa/speakers.php
+++ b/fa/speakers.php
@@ -213,6 +213,6 @@
 
         <?php include "_inc/_footer.php" ?>
 
-        <script type="text/javascript" src="/script.js?ver=1"></script>
+        <script src="/script.js?ver=1"></script>
     </body>
 </html>

--- a/fa/submit.php
+++ b/fa/submit.php
@@ -65,6 +65,6 @@ require "../_submit.php";
 
         <?php include "_inc/_footer.php" ?>
 
-        <script type="text/javascript" src="/script.js?ver=1"></script>
+        <script src="/script.js?ver=1"></script>
     </body>
 </html>


### PR DESCRIPTION
From the MDN:

"Authors are encouraged to omit the attribute if the script refers to JavaScript code rather than specify a MIME type."

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type